### PR TITLE
Fix: Ensure connector failure rates apply correctly to first simulation batch

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -443,7 +443,7 @@ export default function HomePage() {
           processorIncidents: initialProcessorIncidents,
           processorMatrix: initialProcessorMatrix,
           overallSuccessRate: base.overallSuccessRate || 0,
-          connectorWiseFailurePercentage: connectorWiseFailurePercentage,
+          connectorWiseFailurePercentage: prev?.connectorWiseFailurePercentage ? prev.connectorWiseFailurePercentage : connectorWiseFailurePercentage,
         };
       });
 


### PR DESCRIPTION
### Problem

Payment was successful, even if the failure rate is 100% for connectors

### Solution

The fetchMerchantConnectors was problematic because it reset the configured connectorWiseFailurePercentage (e.g., 100% failure rates) back to an empty object. This would happen if fetchMerchantConnectors ran after you had set the failure rates in the UI but before the first batch of payments was processed using those rates. The fix ensures that these user-configured failure rates are preserved even if fetchMerchantConnectors is called again.
