### PR TITLE
remove payments call: Remove call to /payments endpoint and decide success or failure using connector specific failure percentage

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -61,7 +61,6 @@ export function Header({
         <Tabs value={activeTab} onValueChange={onTabChange} className="">
           <TabsList>
             <TabsTrigger value="intelligent-routing">Intelligent Routing</TabsTrigger>
-            {/* <TabsTrigger value="least-cost-routing">Least Cost Routing</TabsTrigger> */}
           </TabsList>
         </Tabs>
       </div>

--- a/src/components/StatsView.tsx
+++ b/src/components/StatsView.tsx
@@ -60,6 +60,7 @@ export function StatsView({
         const calculatedSr = totalPayments > 0 ? (successfulPayments / totalPayments) * 100 : 0;
 
         return {
+          processorId: processorId, // Keep original ID for keying
           processor: processorName,
           sr: calculatedSr, 
           successfulPaymentCount: successfulPayments,

--- a/src/components/analytics/ProcessorSuccessRatesTable.tsx
+++ b/src/components/analytics/ProcessorSuccessRatesTable.tsx
@@ -25,7 +25,7 @@ export function ProcessorSuccessRatesTable({ data }: ProcessorSuccessRatesTableP
             const failedPaymentCount = item.totalPaymentCount - item.successfulPaymentCount;
             const failureRate = item.totalPaymentCount > 0 ? (failedPaymentCount / item.totalPaymentCount) * 100 : 0;
             return (
-              <AccordionItem value={item.processor} key={item.processor}>
+              <AccordionItem value={item.processorId} key={item.processorId}>
                 <AccordionTrigger>
                   <div className="flex justify-between w-full pr-4">
                     <span>{item.processor}</span>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -50,11 +50,10 @@ export interface ControlsState {
     totalPaymentCount: number;      // Actual count
   }>;
   // New Intelligent Routing Parameters
-  minAggregatesSize: number;
-  maxAggregatesSize: number;
-  currentBlockThresholdMaxTotalCount: number;
-  volumeSplit: number;
-  isSuccessBasedRoutingEnabled?: boolean; // Renamed for consistency
+  // minAggregatesSize: number;
+  // maxAggregatesSize: number;
+  // currentBlockThresholdMaxTotalCount: number;
+  // volumeSplit: number;
   // Batch processing parameters
   numberOfBatches?: number;
   batchSize?: number;
@@ -146,6 +145,6 @@ export interface TransactionLogEntry {
   status: string; // e.g., "succeeded", "failed", "pending"
   connector: string; // The connector used for the transaction
   timestamp: number; // epoch milliseconds, to help with sequencing and time-based analysis
-  routingApproach?: 'exploration' | 'exploitation' | 'unknown' | 'N/A'; // Added routing approach
+  routingApproach?: 'exploration' | 'exploitation' | 'default' | 'unknown' | 'N/A'; // Added routing approach
   sr_scores?: Record<string, number>; // Added sr_scores
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -61,6 +61,7 @@ export interface ControlsState {
 
 
 export interface ProcessorSuccessRate {
+  processorId: string;
   processor: string;
   sr: number; // Observed SR
   successfulPaymentCount: number;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,12 +2,3 @@
   --primary: 222 83% 53% !important; /* Tailwind blue-600 */
   --primary-foreground: 0 0% 100% !important;
 }
-.theme-least-cost {
-  --primary: 262 83% 58% !important; /* Tailwind purple-600 */
-  --primary-foreground: 0 0% 100% !important;
-  --sidebar-primary: 262 83% 58%; /* Purple for sidebar icons */
-  --sidebar-primary-foreground: 0 0% 100%;
-  --sidebar-accent: 262 83% 68%; /* Lighter purple for accent */
-  --sidebar-ring: 262 83% 58%;
-  --chart-5: 262 83% 58%; /* Purple for chart icons/lines */
-} 


### PR DESCRIPTION
Instead of hitting /payments endpoint , decide the success or failure of a percentage using random number generation logic. If the random number generated is greater than the connector specific failure percentage, then the payment status is success, otherwise failure. Since this is a testing env, the status would always be same whether we hit /payments endpoint or not. 